### PR TITLE
add support for configuring the 'logbias' zfs attr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /test/support/Gemfile.lock
 /tmp
 *.lock
+.bundle
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Description
 ===========
 
-Lightweight resource and provider to manage Solaris zfs file systems. 
+Lightweight resource and provider to manage Solaris zfs file systems.
 Currently, only a limited sub-set of options are supported.
 
 Requirements
@@ -25,8 +25,8 @@ Attributes
     reservation    - size in B,KB,MB,GB,TB - defaults to "none"
     refreservation - size in B,KB,MB,GB,TB - defaults to "none"
     dedup          - "on", "off" - defaults to "off"
+    logbias        - "latency", "throughput" - defaults to "latency"
 
- 
 Usage
 =====
 
@@ -34,7 +34,7 @@ Usage
       action :create
       mountpoint "/opt/test"
     end
-  
+
     zfs "test/test2" do
       zoned "on"
       atime "off"
@@ -42,7 +42,7 @@ Usage
       mountpoint "none"
       compression "lz4"
     end
-  
+
     zfs "test/test3" do
       action :destroy
     end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'marthag@mit.edu'
 license          'Apache 2.0'
 description      'Manages Solaris zfs'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.6'
+version          '0.0.7'
 
 %w(solaris2 ubuntu freebsd).each do |os|
   supports os

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -6,9 +6,9 @@ def load_current_resource
   case node['platform']
     # freebsd's zfs doesn't support the 'zone' functionality
   when 'freebsd'
-    @managed_props = %w(mountpoint recordsize atime compression quota refquota reservation refreservation dedup)
+    @managed_props = %w(mountpoint recordsize atime compression quota refquota reservation refreservation dedup logbias)
   else
-    @managed_props = %w(mountpoint zoned recordsize atime compression quota refquota reservation refreservation dedup)
+    @managed_props = %w(mountpoint zoned recordsize atime compression quota refquota reservation refreservation dedup logbias)
   end
 
   @zfs.info(info?)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -11,6 +11,7 @@ attribute :refquota, kind_of: String, default: 'none'
 attribute :reservation, kind_of: String, default: 'none'
 attribute :refreservation, kind_of: String, default: 'none'
 attribute :dedup, kind_of: String, equal_to: %w(on off), default: 'off'
+attribute :logbias, kind_of: String, equal_to: %w(latency throughput), default: 'latency'
 
 attribute :info, kind_of: Mixlib::ShellOut, default: nil
 attribute :current_props, kind_of: Hash, default: nil


### PR DESCRIPTION
Since we are using Postgres on ZFS in production, we wanted to set 'logbias' to the recommended 'throughput' setting using your provider. Hope this is helpful :)

/cc @maxdanilov @bixu
